### PR TITLE
fix: Fixed Web Server shutting down after first clip gets played

### DIFF
--- a/Cliparino/src/CPHInline.cs
+++ b/Cliparino/src/CPHInline.cs
@@ -649,7 +649,7 @@ public class CPHInline : CPHInlineBase {
     ///     A task representing the asynchronous operation. The task result contains a boolean indicating
     ///     whether the operation was completed successfully.
     /// </returns>
-    private async Task<bool> HandleStopCommand(bool shutdown = false) {
+    private async Task<bool> HandleStopCommand() {
         _logger.Log(LogLevel.Debug, "Handling !stop command.");
 
         try {

--- a/Cliparino/src/CPHInline.cs
+++ b/Cliparino/src/CPHInline.cs
@@ -193,6 +193,10 @@ public class CPHInline : CPHInlineBase {
         }
     }
 
+    public void Dispose() {
+        _httpManager.StopHosting().GetAwaiter().GetResult();
+    }
+
     /// <summary>
     ///     Handles the "!watch" command to watch Twitch clips. Determines the input type (e.g., URL,
     ///     username, or search term) and processes the request accordingly. Provides fallback to the last
@@ -645,14 +649,14 @@ public class CPHInline : CPHInlineBase {
     ///     A task representing the asynchronous operation. The task result contains a boolean indicating
     ///     whether the operation was completed successfully.
     /// </returns>
-    private async Task<bool> HandleStopCommand() {
+    private async Task<bool> HandleStopCommand(bool shutdown = false) {
         _logger.Log(LogLevel.Debug, "Handling !stop command.");
 
         try {
             await _obsSceneManager.StopClip();
-            await _httpManager.StopHosting();
-
-            _httpManager.Client.CancelPendingRequests();
+            // await _httpManager.StopHosting();
+            //
+            // _httpManager.Client.CancelPendingRequests();
 
             return true;
         } catch (Exception ex) {

--- a/Cliparino/src/Managers/HttpManager.cs
+++ b/Cliparino/src/Managers/HttpManager.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -154,6 +155,21 @@ public class HttpManager {
                 "Content-Security-Policy",
                 $"script-src 'nonce-{nonce}' 'strict-dynamic'; object-src 'none'; base-uri 'none'; frame-ancestors 'self' https://clips.twitch.tv;"
             }
+        };
+    }
+
+    /// <summary>
+    ///     Generates a dictionary containing headers for cache control configuration.
+    ///     (i.e. Disables caching of responses on client browsers.) 
+    /// </summary>
+    /// <returns>
+    ///     A dictionary of headers configured for cache control.
+    /// </returns>
+    private static Dictionary<string, string> GenerateCacheControlHeaders() {
+        return new Dictionary<string, string> {
+            { "Cache-Control", "no-cache, no-store, must-revalidate" },
+            { "Pragma", "no-cache" },
+            { "Expires", "0" },
         };
     }
 
@@ -363,7 +379,10 @@ public class HttpManager {
     ///     The updated <see cref="HttpListenerContext" /> object with the necessary headers applied.
     /// </returns>
     private static HttpListenerContext ReadyHeaders(string nonce, HttpListenerContext context) {
-        var headers = GenerateCORSHeaders(nonce);
+        var headers = new List<Dictionary<string, string>> {
+            GenerateCORSHeaders(nonce),
+            GenerateCacheControlHeaders(),
+        }.SelectMany(dict => dict).ToDictionary(pair => pair.Key, pair => pair.Value);
 
         foreach (var header in headers) context.Response.Headers[header.Key] = header.Value;
 

--- a/Cliparino/src/Managers/ObsSceneManager.cs
+++ b/Cliparino/src/Managers/ObsSceneManager.cs
@@ -127,7 +127,7 @@ public class ObsSceneManager {
     ///     The URL string of the player if found; otherwise, a message indicating no URL was found.
     /// </returns>
     private string GetPlayerUrl() {
-        var playerUrl = GetPlayerSettings()?["url"]?.ToString();
+        var playerUrl = GetPlayerSettings()?["inputSettings"]?["url"]?.ToString();
 
         _logger.Log(LogLevel.Debug, $"Player URL: {playerUrl}");
 


### PR DESCRIPTION
The output of the Raw Generator showed that the `url` in the response object is inside the `inputSettings` field.