### PR TITLE
Feature: use git tag versions for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,24 +26,27 @@ jobs:
     - name: Extract version from tag
       id: version
       shell: bash
-      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-    - name: Update version in project file
-      shell: pwsh
       run: |
-        $version = "${{ steps.version.outputs.VERSION }}"
-        $csproj = "src/Cliparino.Core/Cliparino.Core.csproj"
-        $content = Get-Content $csproj -Raw
-        $content = $content -replace '<Version>.*?</Version>', "<Version>$version</Version>"
-        $content = $content -replace '<AssemblyVersion>.*?</AssemblyVersion>', "<AssemblyVersion>$version.0</AssemblyVersion>"
-        $content = $content -replace '<FileVersion>.*?</FileVersion>', "<FileVersion>$version.0</FileVersion>"
-        Set-Content $csproj $content
+        version="${GITHUB_REF#refs/tags/v}"
+        version_core="${version%%-*}"
+
+        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          echo "Invalid version tag: v$version"
+          exit 1
+        fi
+
+        echo "VERSION=$version" >> "$GITHUB_OUTPUT"
+        echo "VERSION_CORE=$version_core" >> "$GITHUB_OUTPUT"
 
     - name: Restore dependencies
       run: dotnet restore Cliparino.sln
 
     - name: Build solution
-      run: dotnet build Cliparino.sln --configuration Release --no-restore
+      run: >-
+        dotnet build Cliparino.sln --configuration Release --no-restore
+        -p:Version=${{ steps.version.outputs.VERSION }}
+        -p:AssemblyVersion=${{ steps.version.outputs.VERSION_CORE }}.0
+        -p:FileVersion=${{ steps.version.outputs.VERSION_CORE }}.0
 
     - name: Run tests
       run: dotnet test Cliparino.sln --configuration Release --no-build --verbosity normal
@@ -52,7 +55,15 @@ jobs:
       run: dotnet restore src/Cliparino.Core/Cliparino.Core.csproj --runtime win-x64
 
     - name: Publish self-contained application
-      run: dotnet publish src/Cliparino.Core/Cliparino.Core.csproj --configuration Release --runtime win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --output src/Cliparino.Core/bin/Release/net8.0-windows/win-x64/publish
+      run: >-
+        dotnet publish src/Cliparino.Core/Cliparino.Core.csproj --configuration Release
+        --runtime win-x64 --self-contained true
+        -p:PublishSingleFile=true
+        -p:IncludeNativeLibrariesForSelfExtract=true
+        -p:Version=${{ steps.version.outputs.VERSION }}
+        -p:AssemblyVersion=${{ steps.version.outputs.VERSION_CORE }}.0
+        -p:FileVersion=${{ steps.version.outputs.VERSION_CORE }}.0
+        --output src/Cliparino.Core/bin/Release/net8.0-windows/win-x64/publish
 
     - name: Verify publish output
       shell: pwsh
@@ -94,19 +105,12 @@ jobs:
         choco install innosetup --yes --no-progress
         echo "C:\Program Files (x86)\Inno Setup 6" >> $env:GITHUB_PATH
 
-    - name: Update installer version
-      shell: pwsh
-      run: |
-        $version = "${{ steps.version.outputs.VERSION }}"
-        $issFile = "installer/Cliparino.iss"
-        $content = Get-Content $issFile -Raw
-        $content = $content -replace '#define MyAppVersion ".*?"', "#define MyAppVersion `"$version`""
-        Set-Content $issFile $content
-
     - name: Compile installer
       shell: pwsh
       run: |
-        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" "installer/Cliparino.iss"
+        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+          "/DMyAppVersion=${{ steps.version.outputs.VERSION }}" `
+          "installer/Cliparino.iss"
 
     - name: List output directory
       shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <!-- If u do git releases then it will override this but if u local build then it will use this i dunno -->
+    <PropertyGroup>
+        <Version Condition="'$(Version)' == ''">0.0.0-dev</Version>
+        <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">0.0.0.0</AssemblyVersion>
+        <FileVersion Condition="'$(FileVersion)' == ''">0.0.0.0</FileVersion>
+    </PropertyGroup>
+</Project>

--- a/installer/Cliparino.iss
+++ b/installer/Cliparino.iss
@@ -2,7 +2,6 @@
 ; https://jrsoftware.org/isinfo.php
 
 #define MyAppName "Cliparino"
-#define MyAppVersion "2.1.0 "
 #define MyAppPublisher "angrmgmt"
 #define MyAppURL "https://github.com/angrmgmt/Cliparino"
 #define MyAppExeName "Cliparino.Core.exe"

--- a/src/Cliparino.Core/Cliparino.Core.csproj
+++ b/src/Cliparino.Core/Cliparino.Core.csproj
@@ -6,9 +6,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UseWindowsForms>true</UseWindowsForms>
-        <Version>2.1.0</Version>
-        <AssemblyVersion>2.1.0.0</AssemblyVersion>
-        <FileVersion>2.1.0.0</FileVersion>
         <ApplicationIcon>cliparino.ico</ApplicationIcon>
     </PropertyGroup>
 


### PR DESCRIPTION
### Description

Made the CI releases follow git tag version for everything.

### Related Issue

N/A

### Implementation Details

Updated gh release action to extract version from git tag and pass it into the builds.

Added dev fallback versions for local builds and `build` gh action.

Removed hard-coded versions from csproj and `Cliparino.iss`.

### Testing

Tested by commiting and tagging main and checking if releases correctly.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] N/A I have made corresponding changes to the documentation
- [ ] N/A I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] N/A Any dependent changes have been merged and published in downstream modules

### Screenshots (if applicable)

N/A